### PR TITLE
Connect existing templates to Flask routes and static assets

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,20 +2,46 @@ from flask import Flask, render_template
 
 app = Flask(__name__)
 
-# homepage
+
 @app.route("/")
 def home():
     return render_template("index.html")
 
 
-# 如果你有其他页面，比如 login / about，可以这样加
 @app.route("/login")
 def login():
     return render_template("login.html")
 
 
+@app.route("/signup")
+def signup():
+    return render_template("signup.html")
 
 
-# 启动服务器
+@app.route("/ingredients")
+def ingredient_selection():
+    return render_template("ingredient-selection.html")
+
+
+@app.route("/community")
+def community():
+    return render_template("community.html")
+
+
+@app.route("/saved")
+def saved_recipes():
+    return render_template("SavedRecipe.html")
+
+
+@app.route("/profile")
+def profile():
+    return render_template("profile.html")
+
+
+@app.route("/recipe")
+def recipe_detail():
+    return render_template("recipe-detail.html")
+
+
 if __name__ == "__main__":
     app.run(debug=True)

--- a/templates/SavedRecipe.html
+++ b/templates/SavedRecipe.html
@@ -8,20 +8,20 @@
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap">
-  <link rel="stylesheet" href="survivechef-bootstrap-theme.css">
-  <link rel="stylesheet" href="survivechef-animations.css">
-  <link rel="stylesheet" href="SavedRecipe.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-bootstrap-theme.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-animations.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/SavedRecipe.css') }}">
 
 </head>
 <body>
 <!-- Navbar -->
  <nav class="sc-navbar">
-  <a class="sc-logo" href="index.html">survive<span>chef</span></a>
+  <a class="sc-logo" href="{{ url_for('home') }}">survive<span>chef</span></a>
   <div class="sc-nav-links">
-    <a href="#" class="sc-nav-link">recipes</a>
-    <a href="#" class="sc-nav-link">community</a>
-    <a href="saved.html" class="sc-nav-link active">saved</a>
-    <a href="profile.html" class="sc-nav-link">profile</a>
+    <a href="{{ url_for('ingredient_selection') }}" class="sc-nav-link">recipes</a>
+    <a href="{{ url_for('community') }}" class="sc-nav-link">community</a>
+    <a href="{{ url_for('saved_recipes') }}" class="sc-nav-link active">saved</a>
+    <a href="{{ url_for('profile') }}" class="sc-nav-link">profile</a>
     <button class="sc-nav-btn ghost">log out</button>
   </div>
 </nav>
@@ -44,7 +44,7 @@
      <div class="row g-3" id="recipeGrid">
  
     <div class="col-6 col-md-4 sc-fade-up-1" data-title="lazy egg fried rice">
-      <a href="recipe-detail.html" class="recipe-card">
+      <a href="{{ url_for('recipe_detail') }}" class="recipe-card">
         <div class="recipe-card-thumb" style="background:#FFF4E0;">🍳</div>
         <div class="recipe-card-body">
           <div class="recipe-card-title">Lazy Egg Fried Rice</div>
@@ -55,7 +55,7 @@
     </div>
 
     <div class="col-6 col-md-4 sc-fade-up-2" data-title="spicy ramen upgrade">
-      <a href="recipe-detail.html" class="recipe-card">
+      <a href="{{ url_for('recipe_detail') }}" class="recipe-card">
         <div class="recipe-card-thumb" style="background:#FBEAF0;">🍜</div>
         <div class="recipe-card-body">
           <div class="recipe-card-title">Spicy Ramen Upgrade</div>
@@ -66,7 +66,7 @@
     </div>
  
     <div class="col-6 col-md-4 sc-fade-up-3" data-title="3-ingredient pancakes">
-      <a href="recipe-detail.html" class="recipe-card">
+      <a href="{{ url_for('recipe_detail') }}" class="recipe-card">
         <div class="recipe-card-thumb" style="background:#EEE8FF;">🥞</div>
         <div class="recipe-card-body">
           <div class="recipe-card-title">3-Ingredient Pancakes</div>
@@ -77,7 +77,7 @@
     </div>
 
     <div class="col-6 col-md-4 sc-fade-up-1" data-title="tuna salad bowl">
-      <a href="recipe-detail.html" class="recipe-card">
+      <a href="{{ url_for('recipe_detail') }}" class="recipe-card">
         <div class="recipe-card-thumb" style="background:#EAF3DE;">🥗</div>
         <div class="recipe-card-body">
           <div class="recipe-card-title">Tuna Salad Bowl</div>
@@ -88,7 +88,7 @@
     </div>
 
     <div class="col-6 col-md-4 sc-fade-up-2" data-title="microwave mug pizza">
-      <a href="recipe-detail.html" class="recipe-card">
+      <a href="{{ url_for('recipe_detail') }}" class="recipe-card">
         <div class="recipe-card-thumb" style="background:#FFF0F5;">🍕</div>
         <div class="recipe-card-body">
           <div class="recipe-card-title">Microwave Mug Pizza</div>
@@ -99,7 +99,7 @@
     </div>
 
     <div class="col-6 col-md-4 sc-fade-up-3" data-title="banana oat cookies">
-      <a href="recipe-detail.html" class="recipe-card">
+      <a href="{{ url_for('recipe_detail') }}" class="recipe-card">
         <div class="recipe-card-thumb" style="background:#FAEEDA;">🍌</div>
         <div class="recipe-card-body">
           <div class="recipe-card-title">Banana Oat Cookies</div>

--- a/templates/community.html
+++ b/templates/community.html
@@ -7,20 +7,20 @@
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap">
-  <link rel="stylesheet" href="survivechef-bootstrap-theme.css">
-  <link rel="stylesheet" href="survivechef-animations.css">
-  <link rel="stylesheet" href="community.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-bootstrap-theme.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-animations.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/community.css') }}">
 </head>
 <body>
 
   <!-- Navbar -->
   <nav class="sc-navbar">
-    <a class="sc-logo" href="index.html">survive<span>chef</span></a>
+    <a class="sc-logo" href="{{ url_for('home') }}">survive<span>chef</span></a>
     <div class="sc-nav-links">
-      <a href="ingredient-selection.html" class="sc-nav-link">recipes</a>
-      <a href="community.html" class="sc-nav-link active">community</a>
-      <a href="SavedRecipe.html" class="sc-nav-link">saved</a>
-      <a href="profile.html" class="sc-nav-link">profile</a>
+      <a href="{{ url_for('ingredient_selection') }}" class="sc-nav-link">recipes</a>
+      <a href="{{ url_for('community') }}" class="sc-nav-link active">community</a>
+      <a href="{{ url_for('saved_recipes') }}" class="sc-nav-link">saved</a>
+      <a href="{{ url_for('profile') }}" class="sc-nav-link">profile</a>
       <button class="sc-nav-btn ghost">log out</button>
     </div>
   </nav>
@@ -76,7 +76,7 @@
               </div>
               <div class="card-footer-custom">
                 <div class="social-info">❤️ 18 &nbsp; 💬 4</div>
-                <a href="recipe-detail.html" class="view-btn">View</a>
+                <a href="{{ url_for('recipe_detail') }}" class="view-btn">View</a>
               </div>
             </div>
           </div>
@@ -95,7 +95,7 @@
               </div>
               <div class="card-footer-custom">
                 <div class="social-info">❤️ 24 &nbsp; 💬 7</div>
-                <a href="recipe-detail.html" class="view-btn">View</a>
+                <a href="{{ url_for('recipe_detail') }}" class="view-btn">View</a>
               </div>
             </div>
           </div>
@@ -114,7 +114,7 @@
               </div>
               <div class="card-footer-custom">
                 <div class="social-info">❤️ 15 &nbsp; 💬 3</div>
-                <a href="recipe-detail.html" class="view-btn">View</a>
+                <a href="{{ url_for('recipe_detail') }}" class="view-btn">View</a>
               </div>
             </div>
           </div>
@@ -134,7 +134,7 @@
               </div>
               <div class="card-footer-custom">
                 <div class="social-info">❤️ 31 &nbsp; 💬 9</div>
-                <a href="recipe-detail.html" class="view-btn">View</a>
+                <a href="{{ url_for('recipe_detail') }}" class="view-btn">View</a>
               </div>
             </div>
           </div>
@@ -153,7 +153,7 @@
               </div>
               <div class="card-footer-custom">
                 <div class="social-info">❤️ 21 &nbsp; 💬 5</div>
-                <a href="recipe-detail.html" class="view-btn">View</a>
+                <a href="{{ url_for('recipe_detail') }}" class="view-btn">View</a>
               </div>
             </div>
           </div>
@@ -173,7 +173,7 @@
               </div>
               <div class="card-footer-custom">
                 <div class="social-info">❤️ 27 &nbsp; 💬 6</div>
-                <a href="recipe-detail.html" class="view-btn">View</a>
+                <a href="{{ url_for('recipe_detail') }}" class="view-btn">View</a>
               </div>
             </div>
           </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SurviveChef</title>
-//applied from app.py
 <!-- 1. Bootstrap 5 -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 
@@ -55,14 +54,14 @@
   <!-- ── Navbar ── -->
   <!-- ── Navbar ── -->
   <nav class="sc-navbar">
-    <a class="sc-logo" href="#">survive<span>chef</span><span class="sc-logo-badge">✨ beta</span></a>
+    <a class="sc-logo" href="{{ url_for('home') }}">survive<span>chef</span><span class="sc-logo-badge">✨ beta</span></a>
     <!-- Auth area: JS will replace the buttons if logged in -->
     <div class="sc-nav-links" id="sc-nav-auth">
-      <a href="#" class="sc-nav-link">recipes</a>
-      <a href="#" class="sc-nav-link">community</a>
-      <a href="#" class="sc-nav-link">saved</a>
-      <button class="sc-nav-btn ghost" onclick="window.location.href='login.html'">log in</button>
-      <button class="sc-nav-btn solid" onclick="window.location.href='signup.html'">sign up free</button>
+      <a href="{{ url_for('ingredient_selection') }}" class="sc-nav-link">recipes</a>
+      <a href="{{ url_for('community') }}" class="sc-nav-link">community</a>
+      <a href="{{ url_for('saved_recipes') }}" class="sc-nav-link">saved</a>
+      <button class="sc-nav-btn ghost" onclick="window.location.href='{{ url_for('login') }}'">log in</button>
+      <button class="sc-nav-btn solid" onclick="window.location.href='{{ url_for('signup') }}'">sign up free</button>
     </div>
   </nav>
 
@@ -81,19 +80,19 @@
     <p class="sc-sub">pick your ingredients, get cute recipe ideas instantly</p>
 
     <div class="sc-btn-row">
-      <a href="ingredient-selection.html" class="sc-btn btn-find">
+      <a href="{{ url_for('ingredient_selection') }}" class="sc-btn btn-find">
         <span class="sc-btn-icon">🔍</span> find my recipes
       </a>
-      <a href="community.html" class="sc-btn btn-community">
+      <a href="{{ url_for('community') }}" class="sc-btn btn-community">
         <span class="sc-btn-icon">👥</span> community
       </a>
-      <a href="saved.html" class="sc-btn btn-saved">
+      <a href="{{ url_for('saved_recipes') }}" class="sc-btn btn-saved">
         <span class="sc-btn-icon">🔖</span> saved
       </a>
-      <a href="add-recipe.html" class="sc-btn btn-upload">
+      <a href="#" class="sc-btn btn-upload">
         <span class="sc-btn-icon">📤</span> add recipe
       </a>
-      <a href="profile.html" class="sc-btn btn-profile">
+      <a href="{{ url_for('profile') }}" class="sc-btn btn-profile">
         <span class="sc-btn-icon">👤</span> my profile
       </a>
     </div>
@@ -129,8 +128,6 @@
 </div><!-- end .sc-page -->
 
 <!-- Bootstrap JS -->
- <!-- after auth JS -->
-<!applied from app.py, make sure auth.js is after bootstrap bundle->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
 <script src="{{ url_for('static', filename='js/auth.js') }}"></script>

--- a/templates/ingredient-selection.html
+++ b/templates/ingredient-selection.html
@@ -10,10 +10,10 @@
   <!-- Google Font -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap">
   <!-- Shared theme -->
-  <link rel="stylesheet" href="survivechef-bootstrap-theme.css">
-  <link rel="stylesheet" href="survivechef-animations.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-bootstrap-theme.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-animations.css') }}">
   <!-- Ingredient selection page styles -->
-  <link rel="stylesheet" href="ingredient-selection.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/ingredient-selection.css') }}">
   
 </head>
 <body class="sc-hero-bg">
@@ -38,7 +38,7 @@
   <!-- Navbar -->
   <nav class="navbar navbar-expand-lg sticky-top">
     <div class="container">
-      <a class="navbar-brand" href="index.html">
+      <a class="navbar-brand" href="{{ url_for('home') }}">
         survive<span>chef</span><span class="sc-logo-badge">✨ beta</span>
       </a>
 
@@ -49,19 +49,19 @@
       <div class="collapse navbar-collapse" id="scNavbar">
         <ul class="navbar-nav ms-auto align-items-lg-center gap-lg-1">
           <li class="nav-item">
-            <a class="nav-link active" href="ingredient-selection.html">ingredients</a>
+            <a class="nav-link active" href="{{ url_for('ingredient_selection') }}">ingredients</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="community.html">community</a>
+            <a class="nav-link" href="{{ url_for('community') }}">community</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="saved.html">saved</a>
+            <a class="nav-link" href="{{ url_for('saved_recipes') }}">saved</a>
           </li>
           <li class="nav-item ms-lg-2 mt-2 mt-lg-0">
-            <a href="#" class="btn btn-light btn-sm">log in</a>
+            <a href="{{ url_for('login') }}" class="btn btn-light btn-sm">log in</a>
           </li>
           <li class="nav-item ms-lg-2 mt-2 mt-lg-0">
-            <a href="#" class="btn btn-primary btn-sm">sign up free</a>
+            <a href="{{ url_for('signup') }}" class="btn btn-primary btn-sm">sign up free</a>
           </li>
         </ul>
       </div>
@@ -157,8 +157,8 @@
               </div>
 
               <div class="d-grid gap-2">
-                <a href="recipe-results.html" class="btn btn-primary">Find Recipes</a>
-                <a href="index.html" class="btn btn-secondary">Back to Home</a>
+                <a href="#" class="btn btn-primary">Find Recipes</a>
+                <a href="{{ url_for('home') }}" class="btn btn-secondary">Back to Home</a>
               </div>
             </div>
           </div>
@@ -175,6 +175,6 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="ingredient-selection.js"></script>
+  <script src="{{ url_for('static', filename='js/ingredient-selection.js') }}"></script>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -10,10 +10,10 @@
   <!-- Nunito font -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap">
   <!-- SurviveChef brand -->
-  <link rel="stylesheet" href="survivechef-bootstrap-theme.css">
-  <link rel="stylesheet" href="survivechef-animations.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-bootstrap-theme.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-animations.css') }}">
   <!-- Auth page styles -->
-  <link rel="stylesheet" href="auth.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
 </head>
 <body>
 
@@ -37,12 +37,12 @@
 
   <!-- ── Navbar ── -->
   <nav class="auth-nav" aria-label="site navigation">
-    <a class="auth-logo" href="index.html">
+    <a class="auth-logo" href="{{ url_for('home') }}">
       survive<span>chef</span>
       <span class="auth-logo-badge">✨ beta</span>
     </a>
     <span class="auth-nav-hint">
-      no account? <a href="signup.html">sign up free →</a>
+      no account? <a href="{{ url_for('signup') }}">sign up free →</a>
     </span>
   </nav>
 
@@ -97,7 +97,7 @@
           <div class="auth-field">
             <div class="auth-field-label-row">
               <label for="loginPassword">password</label>
-              <a href="forgot-password.html" class="auth-forgot">forgot password?</a>
+              <a href="#" class="auth-forgot">forgot password?</a>
             </div>
             <div class="auth-input-wrap">
               <span class="auth-input-icon" aria-hidden="true">🔒</span>
@@ -142,7 +142,7 @@
 
         <!-- Switch to signup -->
         <p class="auth-switch">
-          don't have an account? <a href="signup.html">sign up free</a>
+          don't have an account? <a href="{{ url_for('signup') }}">sign up free</a>
         </p>
 
       </div><!-- /.auth-card-body -->
@@ -154,10 +154,10 @@
 <!-- Bootstrap JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <!-- Auth logic -->
-<script src="auth.js"></script>
+<script src="{{ url_for('static', filename='js/auth.js') }}"></script>
 <script>
   // Boot: if already logged in, redirect to home
-  Auth.redirectIfLoggedIn('index.html');
+  Auth.redirectIfLoggedIn('{{ url_for("home") }}');
 
   // Wire up social buttons
   document.getElementById('googleBtn').addEventListener('click', () => Auth.socialSignIn('Google'));

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -7,20 +7,20 @@
  
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap">
-  <link rel="stylesheet" href="survivechef-bootstrap-theme.css">
-  <link rel="stylesheet" href="survivechef-animations.css">
-  <link rel="stylesheet" href="profile.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-bootstrap-theme.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-animations.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
  
 </head>
 <body>
     <!-- Navbar -->
 <nav class="sc-navbar">
-  <a class="sc-logo" href="index.html">survive<span>chef</span></a>
+  <a class="sc-logo" href="{{ url_for('home') }}">survive<span>chef</span></a>
   <div class="sc-nav-links">
-    <a href="community.html" class="sc-nav-link">recipes</a>
-    <a href="#" class="sc-nav-link">community</a>
-    <a href="SavedRecipe.html" class="sc-nav-link">saved</a>
-    <a href="profile.html" class="sc-nav-link active">profile</a>
+    <a href="{{ url_for('ingredient_selection') }}" class="sc-nav-link">recipes</a>
+    <a href="{{ url_for('community') }}" class="sc-nav-link">community</a>
+    <a href="{{ url_for('saved_recipes') }}" class="sc-nav-link">saved</a>
+    <a href="{{ url_for('profile') }}" class="sc-nav-link active">profile</a>
     <button class="sc-nav-btn ghost" id="logoutBtn">log out</button>
   </div>
 </nav>
@@ -66,7 +66,7 @@
     <div class="sec-label">recipes you've posted</div>
     <div class="d-flex flex-column gap-3">
  
-      <a href="recipe-detail.html" class="recipe-mini sc-fade-up-1">
+      <a href="{{ url_for('recipe_detail') }}" class="recipe-mini sc-fade-up-1">
         <div class="recipe-mini-emoji">🍳</div>
         <div class="flex-grow-1">
           <div class="recipe-mini-title">Lazy Egg Fried Rice</div>
@@ -75,7 +75,7 @@
         <span class="badge bg-success">Published</span>
       </a>
  
-      <a href="recipe-detail.html" class="recipe-mini sc-fade-up-2">
+      <a href="{{ url_for('recipe_detail') }}" class="recipe-mini sc-fade-up-2">
         <div class="recipe-mini-emoji">🍜</div>
         <div class="flex-grow-1">
           <div class="recipe-mini-title">Instant Ramen Upgrade</div>
@@ -84,7 +84,7 @@
         <span class="badge bg-success">Published</span>
       </a>
  
-      <a href="recipe-detail.html" class="recipe-mini sc-fade-up-3">
+      <a href="{{ url_for('recipe_detail') }}" class="recipe-mini sc-fade-up-3">
         <div class="recipe-mini-emoji">🥚</div>
         <div class="flex-grow-1">
           <div class="recipe-mini-title">Cheesy Scrambled Eggs</div>
@@ -93,7 +93,7 @@
         <span class="badge bg-warning">Draft</span>
       </a>
  
-      <a href="add-recipe.html" class="recipe-mini" style="border-style: dashed; border-color: #C0DD97; background: #F6FBF0; justify-content: center; gap: 8px;">
+      <a href="#" class="recipe-mini" style="border-style: dashed; border-color: #C0DD97; background: #F6FBF0; justify-content: center; gap: 8px;">
         <span style="font-size:20px;">➕</span>
         <span style="font-size:14px; font-weight:800; color:#3B6D11;">add a new recipe</span>
       </a>
@@ -151,7 +151,7 @@
 <!-- Tab: Preferences -->
  
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-<script src="auth.js"></script>
-<script src="profile.js"></script> 
+<script src="{{ url_for('static', filename='js/auth.js') }}"></script>
+<script src="{{ url_for('static', filename='js/profile.js') }}"></script> 
 </body>
 </html>

--- a/templates/recipe-detail.html
+++ b/templates/recipe-detail.html
@@ -12,10 +12,10 @@
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700;900&display=swap" rel="stylesheet">
 
   <!-- Theme -->
-  <link rel="stylesheet" href="survivechef-bootstrap-theme.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-bootstrap-theme.css') }}">
 
   <!-- Custom CSS -->
-  <link rel="stylesheet" href="recipe-detail.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/recipe-detail.css') }}">
 </head>
 
 <body>
@@ -23,7 +23,7 @@
 <!-- Navbar -->
 <nav class="navbar navbar-expand-lg bg-light">
   <div class="container">
-    <a class="navbar-brand fw-bold" href="index.html">survive<span class="text-warning">chef</span></a>
+    <a class="navbar-brand fw-bold" href="{{ url_for('home') }}">survive<span class="text-warning">chef</span></a>
   </div>
 </nav>
 

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -10,10 +10,10 @@
   <!-- Nunito font -->
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&display=swap">
   <!-- SurviveChef brand -->
-  <link rel="stylesheet" href="survivechef-bootstrap-theme.css">
-  <link rel="stylesheet" href="survivechef-animations.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-bootstrap-theme.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/survivechef-animations.css') }}">
   <!-- Auth page styles -->
-  <link rel="stylesheet" href="auth.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
 </head>
 <body>
 
@@ -37,12 +37,12 @@
 
   <!-- ── Navbar ── -->
   <nav class="auth-nav" aria-label="site navigation">
-    <a class="auth-logo" href="index.html">
+    <a class="auth-logo" href="{{ url_for('home') }}">
       survive<span>chef</span>
       <span class="auth-logo-badge">✨ beta</span>
     </a>
     <span class="auth-nav-hint">
-      already a chef? <a href="login.html">log in →</a>
+      already a chef? <a href="{{ url_for('login') }}">log in →</a>
     </span>
   </nav>
 
@@ -171,8 +171,8 @@
             <input type="checkbox" id="agreeTerms" name="terms" required>
             <label for="agreeTerms">
               i agree to the
-              <a href="terms.html" target="_blank">terms of service</a> and
-              <a href="privacy.html" target="_blank">privacy policy</a>
+              <a href="#" target="_blank">terms of service</a> and
+              <a href="#" target="_blank">privacy policy</a>
             </label>
           </div>
           <p class="auth-field-err" id="agreeTermsErr" role="alert" aria-live="polite"></p>
@@ -193,7 +193,7 @@
 
         <!-- Switch to login -->
         <p class="auth-switch">
-          already have an account? <a href="login.html">log in</a>
+          already have an account? <a href="{{ url_for('login') }}">log in</a>
         </p>
 
       </div><!-- /.auth-card-body -->
@@ -205,10 +205,10 @@
 <!-- Bootstrap JS -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 <!-- Auth logic -->
-<script src="auth.js"></script>
+<script src="{{ url_for('static', filename='js/auth.js') }}"></script>
 <script>
   // Boot: if already logged in, redirect to home
-  Auth.redirectIfLoggedIn('index.html');
+  Auth.redirectIfLoggedIn('{{ url_for("home") }}');
 
   // Wire up social buttons
   document.getElementById('googleBtn').addEventListener('click', () => Auth.socialSignIn('Google'));


### PR DESCRIPTION
So  this PR connects  the current SurviveChef frontend pages into Flask by adding routes in app.py and converting the existing templates to use Flask/Jinja links.

### Changes made

added Flask routes for:
home
login
signup
ingredients
community
saved recipes
profile
recipe detail
converted templates to use url_for(...) for:
page navigation
static CSS files
static JS files

### cleaned up the following templates:

index.html
login.html
signup.html
ingredient-selection.html
community.html
profile.html
SavedRecipe.html
recipe-detail.html



the project had been moved into Flask-style templates/ and static/ folders, but most pages were still using raw .html, .css, and .js links
this PR makes the existing UI pages render correctly through Flask and creates a clean base for backend/database work next