### PR TITLE
Create shared navbar component for app pages

### DIFF
--- a/templates/SavedRecipe.html
+++ b/templates/SavedRecipe.html
@@ -14,17 +14,9 @@
 
 </head>
 <body>
-<!-- Navbar -->
- <nav class="sc-navbar">
-  <a class="sc-logo" href="{{ url_for('home') }}">survive<span>chef</span></a>
-  <div class="sc-nav-links">
-    <a href="{{ url_for('ingredient_selection') }}" class="sc-nav-link">recipes</a>
-    <a href="{{ url_for('community') }}" class="sc-nav-link">community</a>
-    <a href="{{ url_for('saved_recipes') }}" class="sc-nav-link active">saved</a>
-    <a href="{{ url_for('profile') }}" class="sc-nav-link">profile</a>
-    <a href="{{ url_for('logout') }}" class="sc-nav-btn ghost">log out</a>
-  </div>
-</nav>
+{% set active_page = 'saved' %}
+{% include 'navbar.html' %}
+
 <!-- Page Header -->
  <div class="page-header sc-fade-up">
   <h1>🔖 Saved Recipes</h1>

--- a/templates/community.html
+++ b/templates/community.html
@@ -13,22 +13,8 @@
 </head>
 <body>
 
-  <!-- Navbar -->
-  <nav class="sc-navbar">
-    <a class="sc-logo" href="{{ url_for('home') }}">survive<span>chef</span></a>
-    <div class="sc-nav-links">
-      <a href="{{ url_for('ingredient_selection') }}" class="sc-nav-link">recipes</a>
-      <a href="{{ url_for('community') }}" class="sc-nav-link active">community</a>
-      <a href="{{ url_for('saved_recipes') }}" class="sc-nav-link">saved</a>
-      {% if is_logged_in %}
-      <a href="{{ url_for('profile') }}" class="sc-nav-link">profile</a>
-      <a href="{{ url_for('logout') }}" class="sc-nav-btn ghost">log out</a>
-      {% else %}
-      <a href="{{ url_for('login') }}" class="sc-nav-btn ghost">log in</a>
-      <a href="{{ url_for('signup') }}" class="sc-nav-btn solid">sign up free</a>
-      {% endif %}
-    </div>
-  </nav>
+  {% set active_page = 'community' %}
+  {% include 'navbar.html' %}
 
   <!-- Header -->
   <header class="community-header">

--- a/templates/ingredient-selection.html
+++ b/templates/ingredient-selection.html
@@ -34,48 +34,9 @@
   <span class="sc-sparkle" style="top:14%; left:18%; width:14px; height:14px; color:#FFB3C6; animation-delay:0s;"></span>
   <span class="sc-sparkle" style="top:24%; right:18%; width:12px; height:12px; color:#B5E8C0; animation-delay:.4s;"></span>
   <span class="sc-sparkle" style="bottom:22%; left:16%; width:11px; height:11px; color:#C8B8FF; animation-delay:.8s;"></span>
-
-  <!-- Navbar -->
-  <nav class="navbar navbar-expand-lg sticky-top">
-    <div class="container">
-      <a class="navbar-brand" href="{{ url_for('home') }}">
-        survive<span>chef</span><span class="sc-logo-badge">✨ beta</span>
-      </a>
-
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#scNavbar" aria-controls="scNavbar" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
-      <div class="collapse navbar-collapse" id="scNavbar">
-        <ul class="navbar-nav ms-auto align-items-lg-center gap-lg-1">
-          <li class="nav-item">
-            <a class="nav-link active" href="{{ url_for('ingredient_selection') }}">ingredients</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('community') }}">community</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('saved_recipes') }}">saved</a>
-          </li>
-          {% if is_logged_in %}
-          <li class="nav-item">
-            <a class="nav-link" href="{{ url_for('profile') }}">profile</a>
-          </li>
-          <li class="nav-item ms-lg-2 mt-2 mt-lg-0">
-            <a href="{{ url_for('logout') }}" class="btn btn-light btn-sm">log out</a>
-          </li>
-          {% else %}
-          <li class="nav-item ms-lg-2 mt-2 mt-lg-0">
-            <a href="{{ url_for('login') }}" class="btn btn-light btn-sm">log in</a>
-          </li>
-          <li class="nav-item ms-lg-2 mt-2 mt-lg-0">
-            <a href="{{ url_for('signup') }}" class="btn btn-primary btn-sm">sign up free</a>
-          </li>
-          {% endif %}
-        </ul>
-      </div>
-    </div>
-  </nav>
+ 
+  {% set active_page = 'recipes' %}
+  {% include 'navbar.html' %}
 
   <main class="ingredient-page-main">
     <div class="container">

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -1,0 +1,41 @@
+<nav class="sc-navbar">
+  <a class="sc-logo" href="{{ url_for('home') }}">
+    survive<span>chef</span><span class="sc-logo-badge">✨ beta</span>
+  </a>
+
+  <div class="sc-nav-links">
+    <a href="{{ url_for('ingredient_selection') }}"
+       class="sc-nav-link {% if active_page == 'ingredients' %}active{% endif %}">
+      ingredients
+    </a>
+
+    <a href="{{ url_for('community') }}"
+       class="sc-nav-link {% if active_page == 'community' %}active{% endif %}">
+      community
+    </a>
+
+    <a href="{{ url_for('saved_recipes') }}"
+       class="sc-nav-link {% if active_page == 'saved' %}active{% endif %}">
+      saved
+    </a>
+
+    {% if is_logged_in %}
+      <a href="{{ url_for('profile') }}"
+         class="sc-nav-link {% if active_page == 'profile' %}active{% endif %}">
+        profile
+      </a>
+
+      <a href="{{ url_for('logout') }}" class="sc-nav-btn ghost">
+        log out
+      </a>
+    {% else %}
+      <a href="{{ url_for('login') }}" class="sc-nav-btn ghost">
+        log in
+      </a>
+
+      <a href="{{ url_for('signup') }}" class="sc-nav-btn solid">
+        sign up free
+      </a>
+    {% endif %}
+  </div>
+</nav>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -5,8 +5,8 @@
 
   <div class="sc-nav-links">
     <a href="{{ url_for('ingredient_selection') }}"
-       class="sc-nav-link {% if active_page == 'ingredients' %}active{% endif %}">
-      ingredients
+    class="sc-nav-link {% if active_page == 'recipes' %}active{% endif %}">
+    recipes
     </a>
 
     <a href="{{ url_for('community') }}"

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -13,17 +13,9 @@
  
 </head>
 <body>
-    <!-- Navbar -->
-<nav class="sc-navbar">
-  <a class="sc-logo" href="{{ url_for('home') }}">survive<span>chef</span></a>
-  <div class="sc-nav-links">
-    <a href="{{ url_for('ingredient_selection') }}" class="sc-nav-link">recipes</a>
-    <a href="{{ url_for('community') }}" class="sc-nav-link">community</a>
-    <a href="{{ url_for('saved_recipes') }}" class="sc-nav-link">saved</a>
-    <a href="{{ url_for('profile') }}" class="sc-nav-link active">profile</a>
-    <a href="{{ url_for('logout') }}" class="sc-nav-btn ghost">log out</a>
-  </div>
-</nav>
+  {% set active_page = 'profile' %}
+  {% include 'navbar.html' %}
+
 <!-- Profile Header -->
 <div class="profile-header">
   <div class="text-center px-3">

--- a/templates/recipe-results.html
+++ b/templates/recipe-results.html
@@ -13,21 +13,8 @@
 </head>
 <body class="results-page">
 
-  <nav class="sc-navbar">
-    <a class="sc-logo" href="{{ url_for('home') }}">survive<span>chef</span></a>
-    <div class="sc-nav-links">
-      <a href="{{ url_for('ingredient_selection') }}" class="sc-nav-link active">recipes</a>
-      <a href="{{ url_for('community') }}" class="sc-nav-link">community</a>
-      <a href="{{ url_for('saved_recipes') }}" class="sc-nav-link">saved</a>
-      {% if is_logged_in %}
-      <a href="{{ url_for('profile') }}" class="sc-nav-link">profile</a>
-      <a href="{{ url_for('logout') }}" class="sc-nav-btn ghost">log out</a>
-      {% else %}
-      <a href="{{ url_for('login') }}" class="sc-nav-btn ghost">log in</a>
-      <a href="{{ url_for('signup') }}" class="sc-nav-btn solid">sign up free</a>
-      {% endif %}
-    </div>
-  </nav>
+  {% set active_page = 'recipes' %}
+  {% include 'navbar.html' %}
 
   <header class="results-hero">
     <div class="container">


### PR DESCRIPTION
Refactored internal app pages to use a shared Jinja navbar include.

## Changes
- Added reusable `navbar.html`
- Unified navbar styling across app pages
- Added active navigation states
- Reduced duplicated navbar code
- Kept separate navbars for landing and auth pages

## Updated Pages
- ingredient selection
- recipe results
- community
- saved recipes
- profile
- recipe detail

Closes #19